### PR TITLE
fix: add minimum_tls_version to sa config

### DIFF
--- a/lib/terraspace_plugin_azurerm/interfaces/backend/storage_account.rb
+++ b/lib/terraspace_plugin_azurerm/interfaces/backend/storage_account.rb
@@ -44,6 +44,7 @@ class TerraspacePluginAzurerm::Interfaces::Backend
         },
         properties: {
           allowBlobPublicAccess: config.storage_account.allow_blob_public_access,
+          minimumTlsVersion: config.storage_account.minimum_tls_version,
         },
         kind: "StorageV2",
         tags: config.tags,

--- a/lib/terraspace_plugin_azurerm/interfaces/config.rb
+++ b/lib/terraspace_plugin_azurerm/interfaces/config.rb
@@ -29,6 +29,7 @@ module TerraspacePluginAzurerm::Interfaces
       c.storage_account.sku.name = "Standard_LRS"
       c.storage_account.sku.tier = "Standard"
       c.storage_account.allow_blob_public_access = false # Azure default is true
+      c.storage_account.minimum_tls_version = "TLS1_2"
 
       # data protection management
       c.storage_account.configure_data_protection_for_existing = false

--- a/lib/terraspace_plugin_azurerm/version.rb
+++ b/lib/terraspace_plugin_azurerm/version.rb
@@ -1,3 +1,3 @@
 module TerraspacePluginAzurerm
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
Azure support for TLS 1.0 and TLS 1.1 will end by 31 October 2024

https://azure.microsoft.com/en-us/updates/azure-support-tls-will-end-by-31-october-2024-2/